### PR TITLE
refactor: merge TestDesigner+TestExecutor into single Tester agent; add schedule fixture

### DIFF
--- a/scripts/fixtures/repo_fixture_creation/prompts/01_pr_research_prompt.md
+++ b/scripts/fixtures/repo_fixture_creation/prompts/01_pr_research_prompt.md
@@ -6,11 +6,11 @@ Substitute `{{TARGET_REPO}}` with the actual repo before invoking this prompt.
 
 ---
 
-You are a research agent. Search `{{TARGET_REPO}}` on GitHub and identify **5 merged pull
+You are a research agent. Search `{{TARGET_REPO}}` on GitHub and identify **10 merged pull
 requests** that each fixed exactly one issue. These become integration test fixture assets
 for the agent_agent evaluation harness.
 
-Produce 5 entries in `staging/<repo-slug>.json`, where `<repo-slug>` is the last
+Produce 10 entries in `staging/<repo-slug>.json`, where `<repo-slug>` is the last
 component of `{{TARGET_REPO}}` (e.g. `staging/schema.json` for `keleshev/schema`).
 Create the file if it does not exist. Do not overwrite or remove any existing entries
 — only append.
@@ -19,7 +19,7 @@ Create the file if it does not exist. Do not overwrite or remove any existing en
 
 ## Complexity Distribution
 
-You must produce exactly: **3 easy, 1 medium, 1 hard**
+You must produce exactly: **3 easy, 3 medium, 4 hard**
 
 | Tier | Source files changed | LOC delta (non-test) | Issue clarity |
 |------|---------------------|----------------------|---------------|
@@ -60,9 +60,9 @@ Maintain three pools and their targets:
 
 | Pool | Target | Can exceed? |
 |------|--------|-------------|
-| easy | 2 | Yes — stop adding once you have 2+, but don't discard extras |
-| medium | 2 | Yes |
-| hard | 1 | Yes |
+| easy | 3 | Yes — stop adding once you have 3+, but don't discard extras |
+| medium | 3 | Yes |
+| hard | 4 | Yes |
 
 Processing stops when all three pools are at or above their targets.
 
@@ -104,7 +104,7 @@ gh pr view <number> --repo {{TARGET_REPO}} --json files,additions,deletions
 Classify the PR as `easy`, `medium`, or `hard` using the complexity table at the top of
 this prompt (source files changed + non-test LOC delta).
 
-**If the pool for this complexity already has 2+ (easy/medium) or 1+ (hard) accepted
+**If the pool for this complexity already has 3+ (easy/medium) or 4+ (hard) accepted
 entries at dispatch time:** return `skip: "pool full for <tier>"`. Do not proceed to
 Check 2.
 
@@ -279,7 +279,7 @@ This working note is what flows directly into the output JSON — no further mod
 
 ## Output
 
-Append 5 entries to `staging/<repo-slug>.json` (e.g. `staging/schema.json`), creating
+Append 10 entries to `staging/<repo-slug>.json` (e.g. `staging/schema.json`), creating
 it as a JSON array if it does not exist.
 
 ```json
@@ -309,8 +309,8 @@ it as a JSON array if it does not exist.
 | `synthetic_issue` | `false` for real single-issue fixtures; `true` if Step 3b merged two issues |
 | `merged_from` | Empty array normally; `[N, M]` if two issues were merged |
 
-Final distribution check before writing: confirm you have 3 easy, 1 medium, 1 hard.
-All 5 entries must have different `pr_number` and different `issue_number`.
+Final distribution check before writing: confirm you have 3 easy, 3 medium, 4 hard.
+All 10 entries must have different `pr_number` and different `issue_number`.
 
 ---
 

--- a/src/agent_agent/agents/coding.py
+++ b/src/agent_agent/agents/coding.py
@@ -1,9 +1,9 @@
 """Coding composite — iterative nested DAG of sub-agents.
 
 Internal cycle (max 3 cycles) [P10.4]:
-  Programmer -> Test Designer -> Test Executor -> Debugger
+  Programmer -> Tester -> Debugger
 
-Each cycle is a 4-node acyclic DAG persisted before execution [P1.8].
+Each cycle is a 3-node acyclic DAG persisted before execution [P1.8].
 Sub-agent outputs are persisted after each step for resumption [P10.5].
 Programmer and Debugger handle own git staging/committing [P10.13].
 Push-on-exit is composite-level [P10.13].
@@ -26,12 +26,11 @@ from ..observability import EventType, emit_event
 from ..state import StateStore
 from ..worktree import WorktreeRecord
 from .base import SubAgentConfig, compute_sdk_backstop, invoke_agent
-from .prompts import DEBUGGER, PROGRAMMER, TEST_DESIGNER, TEST_EXECUTOR
+from .prompts import DEBUGGER, PROGRAMMER, TESTER
 from .tools import (
     debugger_allowed_tools,
     programmer_allowed_tools,
-    test_designer_allowed_tools,
-    test_executor_allowed_tools,
+    tester_allowed_tools,
 )
 
 _logger = structlog.get_logger(__name__)
@@ -109,8 +108,8 @@ class CodingComposite:
                     dag_run_id, node_id, cycle, "programmer", programmer_output
                 )
 
-                # --- Test Designer ---
-                test_plan_output, cost = await self._invoke_test_designer(
+                # --- Tester ---
+                test_results, cost = await self._invoke_tester(
                     node_context,
                     dag_run_id,
                     node_id,
@@ -118,26 +117,13 @@ class CodingComposite:
                     code_output=programmer_output,
                 )
                 total_cost += cost
-                await self._persist_sub_agent_output(
-                    dag_run_id, node_id, cycle, "test_designer", test_plan_output
-                )
 
-                # --- Test Executor ---
-                test_results, cost = await self._invoke_test_executor(
-                    node_context,
-                    dag_run_id,
-                    node_id,
-                    cycle,
-                    test_plan=test_plan_output,
-                )
-                total_cost += cost
-
-                # --- Post-Test Executor validation: net-zero source changes [P3.3] ---
+                # --- Post-Tester validation: net-zero source changes [P3.3] ---
                 await self._validate_no_source_modifications(dag_run_id, node_id, cycle)
 
                 last_test_output = test_results
                 await self._persist_sub_agent_output(
-                    dag_run_id, node_id, cycle, "test_executor", test_results
+                    dag_run_id, node_id, cycle, "tester", test_results
                 )
 
                 # Check if tests pass -> done
@@ -241,7 +227,7 @@ class CodingComposite:
             raise AgentError(f"Programmer expected CodeOutput, got {type(output).__name__}")
         return output, cost
 
-    async def _invoke_test_designer(
+    async def _invoke_tester(
         self,
         node_context: NodeContext,
         dag_run_id: str,
@@ -253,11 +239,11 @@ class CodingComposite:
         augmented = self._augment_context_with_output(node_context, "programmer", code_output)
 
         config = SubAgentConfig(
-            name="test_designer",
-            system_prompt=TEST_DESIGNER.format(worktree_path=self._worktree.path),
-            allowed_tools=test_designer_allowed_tools(),
+            name="tester",
+            system_prompt=TESTER.format(worktree_path=self._worktree.path),
+            allowed_tools=tester_allowed_tools(),
             output_model=AgentTestOutput,
-            max_turns=self._settings.test_designer_max_turns,
+            max_turns=self._settings.tester_max_turns,
         )
 
         output, cost = await invoke_agent(
@@ -270,45 +256,10 @@ class CodingComposite:
             ),
             cwd=self._worktree.path,
             dag_run_id=dag_run_id,
-            node_id=f"{node_id}-cycle{cycle}-test_designer",
+            node_id=f"{node_id}-cycle{cycle}-tester",
         )
         if not isinstance(output, AgentTestOutput):
-            raise AgentError(f"TestDesigner expected AgentTestOutput, got {type(output).__name__}")
-        return output, cost
-
-    async def _invoke_test_executor(
-        self,
-        node_context: NodeContext,
-        dag_run_id: str,
-        node_id: str,
-        cycle: int,
-        test_plan: AgentTestOutput,
-    ) -> tuple[AgentTestOutput, float]:
-        system_prompt = TEST_EXECUTOR.format(worktree_path=self._worktree.path)
-        augmented = self._augment_context_with_output(node_context, "test_designer", test_plan)
-
-        config = SubAgentConfig(
-            name="test_executor",
-            system_prompt=system_prompt,
-            allowed_tools=test_executor_allowed_tools(),
-            output_model=AgentTestOutput,
-            max_turns=self._settings.test_executor_max_turns,
-        )
-
-        output, cost = await invoke_agent(
-            config=config,
-            node_context=augmented,
-            model=self._settings.model,
-            sdk_budget_backstop_usd=compute_sdk_backstop(
-                self._budget.remaining_node(node_id),
-                self._settings.max_budget_usd,
-            ),
-            cwd=self._worktree.path,
-            dag_run_id=dag_run_id,
-            node_id=f"{node_id}-cycle{cycle}-test_executor",
-        )
-        if not isinstance(output, AgentTestOutput):
-            raise AgentError(f"TestExecutor expected AgentTestOutput, got {type(output).__name__}")
+            raise AgentError(f"Tester expected AgentTestOutput, got {type(output).__name__}")
         return output, cost
 
     async def _invoke_debugger(
@@ -324,7 +275,7 @@ class CodingComposite:
         # Include both CodeOutput and TestOutput in context
         augmented = self._augment_context_with_outputs(
             node_context,
-            {"programmer": code_output, "test_executor": test_results},
+            {"programmer": code_output, "tester": test_results},
         )
 
         config = SubAgentConfig(
@@ -387,8 +338,8 @@ class CodingComposite:
             emit_event(
                 EventType.TOOL_DENIED,
                 dag_run_id,
-                node_id=f"{node_id}-cycle{cycle}-test_executor",
-                reason="test_executor_modified_source_files",
+                node_id=f"{node_id}-cycle{cycle}-tester",
+                reason="tester_modified_source_files",
                 files=modified_files,
             )
             # Revert source file changes to restore Programmer's committed state

--- a/src/agent_agent/agents/prompts.py
+++ b/src/agent_agent/agents/prompts.py
@@ -114,51 +114,29 @@ optionally inside a ```json fence.
   Do NOT omit required fields. Do NOT use other type values.
 """
 
-TEST_DESIGNER = """\
-You are a Test Designer agent. You design test plans for code changes.
+TESTER = """\
+You are a Tester agent. You design and execute tests for code changes in one pass.
 
 ## Role
 - Review the Programmer's CodeOutput to understand what changed
-- Design a test plan covering the changes: what to test, edge cases, assertions
-- Do NOT write test files or run tests -- only produce a plan
-
-## Constraints
-- You have READ-ONLY access
-- Do not modify any files
-- Read files from the worktree directory only: {worktree_path} — do NOT read from the repo root
-- Focus on testable behaviors, not implementation details
-
-## Output Format
-Return a JSON object matching the AgentTestOutput schema:
-- `type`: always "test"
-- `role`: always "plan"
-- `summary`: brief summary of the test strategy
-- `test_plan`: detailed prose description of what to test and how
-- `discoveries`: MUST be `[]`. Do NOT put anything here. This field is not for test agents.
-"""
-
-TEST_EXECUTOR = """\
-You are a Test Executor agent. You run the test suite and report results.
-
-## Role
-- Review the Test Designer's test plan in your upstream context before running tests. \
-  If it identifies specific test files or commands, run those first.
-- Run the test suite in the worktree directory: {worktree_path}
+- Design a test plan: what to test, edge cases, assertions
+- Execute the tests following your plan in the worktree directory: {worktree_path}
 - Report pass/fail status and failure details
 - Do NOT fix failing tests -- that is the Debugger's job
 
 ## Constraints
-- Work within the worktree directory
-- Do not modify source files -- any source file changes will be detected and rejected
+- Work within the worktree directory only: {worktree_path}
+- Do NOT modify source files written by the Programmer -- any such changes will be \
+  detected and rejected. Test files you create or modify are fine.
 - Do not perform git operations (commit, add, push, checkout, etc.)
 - Run tests using the project's configured test runner
-- You may create temporary files if needed for test execution (they will be cleaned up)
 
 ## Output Format
 Return a JSON object matching the AgentTestOutput schema:
 - `type`: always "test"
-- `role`: always "results"
-- `summary`: brief summary of test results
+- `role`: always "tester"
+- `summary`: brief summary of test strategy and results
+- `test_plan`: prose description of what you tested and how
 - `passed`: true if all tests pass, false otherwise
 - `total_tests`: number of tests run
 - `failed_tests`: number of failures

--- a/src/agent_agent/agents/tools.py
+++ b/src/agent_agent/agents/tools.py
@@ -16,13 +16,8 @@ def programmer_allowed_tools() -> list[str]:
     return ["Read", "Glob", "Grep", "Write", "Edit", "Bash"]
 
 
-def test_designer_allowed_tools() -> list[str]:
-    """Test Designer: read-only [P3.3]."""
-    return ["Read", "Glob", "Grep", "Bash"]
-
-
-def test_executor_allowed_tools() -> list[str]:
-    """Test Executor: read + run tests [P3.3]."""
+def tester_allowed_tools() -> list[str]:
+    """Tester: read + write + run tests [P3.3]."""
     return ["Read", "Glob", "Grep", "Write", "Edit", "Bash"]
 
 

--- a/src/agent_agent/config.py
+++ b/src/agent_agent/config.py
@@ -48,8 +48,7 @@ class Settings(BaseSettings):
 
     # CodingComposite sub-agent turn caps
     programmer_max_turns: int = 100
-    test_designer_max_turns: int = 15
-    test_executor_max_turns: int = 100
+    tester_max_turns: int = 115
     debugger_max_turns: int = 100
     reviewer_max_turns: int = 20
 

--- a/src/agent_agent/models/agent.py
+++ b/src/agent_agent/models/agent.py
@@ -103,6 +103,7 @@ class CodeOutput(BaseModel):
 class AgentTestRole(str, Enum):
     PLAN = "plan"
     RESULTS = "results"
+    TESTER = "tester"
 
 
 class AgentTestOutput(BaseModel):

--- a/tests/component/test_coding_composite.py
+++ b/tests/component/test_coding_composite.py
@@ -42,8 +42,7 @@ def _make_settings(**overrides: Any) -> Settings:
         "max_budget_usd": 1.0,
         "git_push_enabled": True,
         "programmer_max_turns": 100,
-        "test_designer_max_turns": 100,
-        "test_executor_max_turns": 100,
+        "tester_max_turns": 100,
         "debugger_max_turns": 100,
     }
     defaults.update(overrides)
@@ -349,7 +348,7 @@ class TestCodingCompositeSubAgentsPersisted:
 
         # Verify sub-agent outputs were persisted
         entries = await state_store.list_shared_context("run-1")
-        assert len(entries) >= 3  # At least programmer + test_designer + test_executor
+        assert len(entries) >= 2  # At least programmer + tester
         categories = [e["category"] for e in entries]
         assert all(c == "sub_agent_output" for c in categories)
 

--- a/tests/fixtures/schedule.json
+++ b/tests/fixtures/schedule.json
@@ -1,0 +1,15 @@
+[
+  {
+    "fixture_id": "schedule-recursion-repr",
+    "complexity": "easy",
+    "upstream": "https://github.com/dbader/schedule",
+    "base_sha": "3108fc3194c2f3071d6e41adfd21577fc62c52fc",
+    "license": "MIT",
+    "pr_number": 277,
+    "issue_number": 190,
+    "issue_title": "Job.__repr__ causes a RecursionError when the job is passed to the do function as an arg.",
+    "issue_body": "I wish to pass the job instance to the do function of the same job i.e. `do(some_function, job)`.  However, due to the way repr is defined for job this causes a `RecursionError`.\r\nThis is the culprit:\r\n```python\r\nargs = [repr(x) for x in self.job_func.args]\r\n```",
+    "synthetic_issue": false,
+    "merged_from": []
+  }
+]

--- a/tests/integration/test_phase5_e2e.py
+++ b/tests/integration/test_phase5_e2e.py
@@ -66,8 +66,7 @@ def _make_settings(worktree_base: str, port: int = 19300) -> Settings:
         plan_thinking_budget_tokens=0,
         plan_max_turns=100,
         programmer_max_turns=100,
-        test_designer_max_turns=100,
-        test_executor_max_turns=100,
+        tester_max_turns=100,
         debugger_max_turns=100,
         reviewer_max_turns=100,
     )

--- a/tests/unit/test_coding_composite.py
+++ b/tests/unit/test_coding_composite.py
@@ -100,20 +100,12 @@ def _make_code_output(
     )
 
 
-def _make_test_plan_output() -> AgentTestOutput:
-    return AgentTestOutput(
-        type="test",
-        role=AgentTestRole.PLAN,
-        summary="Test plan for changes",
-        test_plan="Run pytest on src/test_main.py",
-    )
-
-
 def _make_test_results(passed: bool = True) -> AgentTestOutput:
     return AgentTestOutput(
         type="test",
-        role=AgentTestRole.RESULTS,
+        role=AgentTestRole.TESTER,
         summary="Tests passed" if passed else "Tests failed",
+        test_plan="Run pytest on the worktree",
         passed=passed,
         total_tests=5,
         failed_tests=0 if passed else 2,
@@ -158,13 +150,11 @@ class TestCodingCompositeOneCycle:
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_single_cycle_on_pass(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),  # programmer
-            (test_plan, 0.03),  # test_designer
-            (test_results, 0.05),  # test_executor
+            (test_results, 0.05),  # tester
         ]
 
         composite = _make_composite()
@@ -176,8 +166,8 @@ class TestCodingCompositeOneCycle:
 
         assert result.tests_passed is True
         assert result.branch_name == _BRANCH
-        assert mock_invoke.call_count == 3  # no debugger
-        assert total_cost == pytest.approx(0.18)
+        assert mock_invoke.call_count == 2  # no debugger
+        assert total_cost == pytest.approx(0.15)
 
 
 class TestCodingCompositeMaxCycles:
@@ -189,17 +179,15 @@ class TestCodingCompositeMaxCycles:
         self, mock_invoke: AsyncMock, _mock_sub: MagicMock
     ) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_fail = _make_test_results(passed=False)
         debugger_out = _make_code_output(summary="debugger fix")
 
-        # 3 cycles: each has Programmer + TestDesigner + TestExecutor
+        # 3 cycles: each has Programmer + Tester
         # Cycles 0 and 1 also get Debugger (cycle 2 is last, no debugger)
         side_effects = []
         for cycle in range(MAX_CYCLES):
             side_effects.append((code_out, 0.10))  # programmer
-            side_effects.append((test_plan, 0.03))  # test_designer
-            side_effects.append((test_fail, 0.05))  # test_executor
+            side_effects.append((test_fail, 0.05))  # tester
             if cycle + 1 < MAX_CYCLES:
                 side_effects.append((debugger_out, 0.08))  # debugger
 
@@ -213,8 +201,8 @@ class TestCodingCompositeMaxCycles:
         )
 
         assert result.tests_passed is False
-        # 3 * (programmer + test_designer + test_executor) + 2 debugger = 11
-        assert mock_invoke.call_count == 11
+        # 3 * (programmer + tester) + 2 debugger = 8
+        assert mock_invoke.call_count == 8
 
 
 class TestCodingCompositeSkipsDebuggerLastCycle:
@@ -226,14 +214,12 @@ class TestCodingCompositeSkipsDebuggerLastCycle:
         self, mock_invoke: AsyncMock, _mock_sub: MagicMock
     ) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_fail = _make_test_results(passed=False)
         debugger_out = _make_code_output(summary="debugger fix")
 
         side_effects = []
         for cycle in range(MAX_CYCLES):
             side_effects.append((code_out, 0.10))
-            side_effects.append((test_plan, 0.03))
             side_effects.append((test_fail, 0.05))
             if cycle + 1 < MAX_CYCLES:
                 side_effects.append((debugger_out, 0.08))
@@ -248,11 +234,11 @@ class TestCodingCompositeSkipsDebuggerLastCycle:
         )
 
         # Verify the last cycle's calls don't include debugger
-        # Last 3 calls should be: programmer, test_designer, test_executor (no debugger)
-        last_three_configs = [
-            call.kwargs["config"].name for call in mock_invoke.call_args_list[-3:]
+        # Last 2 calls should be: programmer, tester (no debugger)
+        last_two_configs = [
+            call.kwargs["config"].name for call in mock_invoke.call_args_list[-2:]
         ]
-        assert last_three_configs == ["programmer", "test_designer", "test_executor"]
+        assert last_two_configs == ["programmer", "tester"]
 
 
 class TestCodingCompositePushOnExit:
@@ -285,12 +271,10 @@ class TestCodingCompositePushSkipped:
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_push_skipped(self, mock_invoke: AsyncMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 
@@ -316,12 +300,10 @@ class TestCodingCompositeSubAgentPersistence:
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_outputs_persisted(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 
@@ -334,8 +316,8 @@ class TestCodingCompositeSubAgentPersistence:
             node_id="code-node",
         )
 
-        # 3 persist calls: programmer, test_designer, test_executor
-        assert state.append_shared_context.call_count == 3
+        # 2 persist calls: programmer, tester
+        assert state.append_shared_context.call_count == 2
         categories = [
             call.kwargs["category"] for call in state.append_shared_context.call_args_list
         ]
@@ -351,19 +333,16 @@ class TestCodingCompositeContextAugmentation:
         self, mock_invoke: AsyncMock, _mock_sub: MagicMock
     ) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_fail = _make_test_results(passed=False)
         debugger_out = _make_code_output(summary="debugger fix")
         test_pass = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
-            (code_out, 0.10),  # cycle 0: programmer
-            (test_plan, 0.03),  # cycle 0: test_designer
-            (test_fail, 0.05),  # cycle 0: test_executor
+            (code_out, 0.10),    # cycle 0: programmer
+            (test_fail, 0.05),   # cycle 0: tester
             (debugger_out, 0.08),  # cycle 0: debugger
-            (code_out, 0.10),  # cycle 1: programmer
-            (test_plan, 0.03),  # cycle 1: test_designer
-            (test_pass, 0.05),  # cycle 1: test_executor
+            (code_out, 0.10),    # cycle 1: programmer
+            (test_pass, 0.05),   # cycle 1: tester
         ]
 
         composite = _make_composite()
@@ -373,8 +352,8 @@ class TestCodingCompositeContextAugmentation:
             node_id="code-node",
         )
 
-        # The cycle 1 programmer call (5th call, index 4) should have augmented context
-        cycle1_programmer_call = mock_invoke.call_args_list[4]
+        # The cycle 1 programmer call (4th call, index 3) should have augmented context
+        cycle1_programmer_call = mock_invoke.call_args_list[3]
         ctx = cycle1_programmer_call.kwargs["node_context"]
         assert "prev-cycle-0-test" in ctx.parent_outputs
 
@@ -386,12 +365,10 @@ class TestCodingCompositeProgrammerConfig:
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_programmer_config(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 
@@ -412,19 +389,17 @@ class TestCodingCompositeProgrammerConfig:
         assert "Write" in programmer_config.allowed_tools
 
 
-class TestCodingCompositeTestDesignerConfig:
-    """Test 9: Test Designer config: max_turns from settings, read-only."""
+class TestCodingCompositeTesterConfig:
+    """Test 9: Tester config: max_turns from settings, write tools."""
 
     @patch("agent_agent.agents.coding.subprocess.run", side_effect=_clean_subprocess_mock)
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
-    async def test_test_designer_config(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
+    async def test_tester_config(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 
@@ -435,66 +410,34 @@ class TestCodingCompositeTestDesignerConfig:
             node_id="code-node",
         )
 
-        td_config = mock_invoke.call_args_list[1].kwargs["config"]
-        assert td_config.name == "test_designer"
-        assert td_config.max_turns == _make_settings().test_designer_max_turns
+        tester_config = mock_invoke.call_args_list[1].kwargs["config"]
+        assert tester_config.name == "tester"
+        assert tester_config.max_turns == _make_settings().tester_max_turns
 
-        assert "Edit" not in td_config.allowed_tools
-        assert "Write" not in td_config.allowed_tools
-
-
-class TestCodingCompositeTestExecutorConfig:
-    """Test 10: Test Executor config: max_turns from settings, test execution tools."""
-
-    @patch("agent_agent.agents.coding.subprocess.run", side_effect=_clean_subprocess_mock)
-    @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
-    async def test_test_executor_config(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
-        code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
-        test_results = _make_test_results(passed=True)
-
-        mock_invoke.side_effect = [
-            (code_out, 0.10),
-            (test_plan, 0.03),
-            (test_results, 0.05),
-        ]
-
-        composite = _make_composite()
-        await composite.execute(
-            node_context=_make_node_context(),
-            dag_run_id="run-1",
-            node_id="code-node",
-        )
-
-        te_config = mock_invoke.call_args_list[2].kwargs["config"]
-        assert te_config.name == "test_executor"
-        assert te_config.max_turns == _make_settings().test_executor_max_turns
-
-        assert "Bash" in te_config.allowed_tools
-        assert "Read" in te_config.allowed_tools
+        assert "Write" in tester_config.allowed_tools
+        assert "Edit" in tester_config.allowed_tools
+        assert "Bash" in tester_config.allowed_tools
+        assert "Read" in tester_config.allowed_tools
 
 
 class TestCodingCompositeDebuggerConfig:
-    """Test 11: Debugger config: max_turns from settings, write tools."""
+    """Test 10: Debugger config: max_turns from settings, write tools."""
 
     @patch("agent_agent.agents.coding.subprocess.run", side_effect=_clean_subprocess_mock)
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_debugger_config(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_fail = _make_test_results(passed=False)
         debugger_out = _make_code_output(summary="debugger fix")
         # Second cycle passes
         test_pass = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
-            (code_out, 0.10),  # cycle 0: programmer
-            (test_plan, 0.03),  # cycle 0: test_designer
-            (test_fail, 0.05),  # cycle 0: test_executor
+            (code_out, 0.10),    # cycle 0: programmer
+            (test_fail, 0.05),   # cycle 0: tester
             (debugger_out, 0.08),  # cycle 0: debugger
-            (code_out, 0.10),  # cycle 1: programmer
-            (test_plan, 0.03),  # cycle 1: test_designer
-            (test_pass, 0.05),  # cycle 1: test_executor
+            (code_out, 0.10),    # cycle 1: programmer
+            (test_pass, 0.05),   # cycle 1: tester
         ]
 
         composite = _make_composite()
@@ -504,7 +447,7 @@ class TestCodingCompositeDebuggerConfig:
             node_id="code-node",
         )
 
-        dbg_config = mock_invoke.call_args_list[3].kwargs["config"]
+        dbg_config = mock_invoke.call_args_list[2].kwargs["config"]
         assert dbg_config.name == "debugger"
         assert dbg_config.max_turns == _make_settings().debugger_max_turns
         assert dbg_config.output_model is CodeOutput
@@ -514,18 +457,16 @@ class TestCodingCompositeDebuggerConfig:
 
 
 class TestCodingCompositeBranchName:
-    """Test 12: Branch name in output matches worktree.branch."""
+    """Test 11: Branch name in output matches worktree.branch."""
 
     @patch("agent_agent.agents.coding.subprocess.run", side_effect=_clean_subprocess_mock)
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_branch_name_matches(self, mock_invoke: AsyncMock, _mock_sub: MagicMock) -> None:
         code_out = _make_code_output(branch="some-other-branch")
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 
@@ -541,17 +482,15 @@ class TestCodingCompositeBranchName:
 
 
 class TestCodingCompositePushFailure:
-    """Test 13: Push failure — verify composite still returns, push logged, state updated."""
+    """Test 12: Push failure — verify composite still returns, push logged, state updated."""
 
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_push_failure_handled(self, mock_invoke: AsyncMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 
@@ -591,17 +530,15 @@ class TestCodingCompositePushFailure:
 
 
 class TestCodingCompositeGitDiffModified:
-    """Test 14: Post-test git diff returns modified files -> AgentError + revert."""
+    """Test 13: Post-test git diff returns modified files -> AgentError + revert."""
 
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_git_diff_modified_raises(self, mock_invoke: AsyncMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 
@@ -629,17 +566,15 @@ class TestCodingCompositeGitDiffModified:
 
 
 class TestCodingCompositeGitDiffClean:
-    """Test 15: Post-test git diff returns empty -> no error, cycle continues."""
+    """Test 14: Post-test git diff returns empty -> no error, cycle continues."""
 
     @patch("agent_agent.agents.coding.invoke_agent", new_callable=AsyncMock)
     async def test_git_diff_clean_continues(self, mock_invoke: AsyncMock) -> None:
         code_out = _make_code_output()
-        test_plan = _make_test_plan_output()
         test_results = _make_test_results(passed=True)
 
         mock_invoke.side_effect = [
             (code_out, 0.10),
-            (test_plan, 0.03),
             (test_results, 0.05),
         ]
 


### PR DESCRIPTION
## Why we're merging the two agents

The coding cycle previously ran four nodes per iteration:

```
Programmer → TestDesigner → TestExecutor → Debugger
```

`TestDesigner` was read-only (no Write/Edit tools) and produced an `AgentTestOutput(role=PLAN)` consumed immediately by `TestExecutor`. `TestExecutor` then ran the tests and produced `AgentTestOutput(role=RESULTS)`. This split predated the current composite architecture and was never mandated by policy — P10.4 describes the cycle as `Programmer → Tester → Debugger` (three nodes, not four).

Keeping the split had real costs:
- Two SDK round-trips per cycle where one suffices
- Two separate turn-cap settings (`test_designer_max_turns=15`, `test_executor_max_turns=100`) that had to be tuned together
- An intermediate `AgentTestOutput(role=PLAN)` that was only ever consumed by the immediately following agent and never surfaced to the Debugger
- The Debugger received no visibility into the test plan — only the raw failure output

The merged `Tester` agent designs and executes tests in a single pass. Its output populates both `test_plan` and the results fields (`passed`, `total_tests`, `failed_tests`, `failure_details`), giving the Debugger full context when tests fail.

## Changes

| File | Change |
|---|---|
| `models/agent.py` | Added `AgentTestRole.TESTER = "tester"` |
| `agents/tools.py` | Replaced `test_designer_allowed_tools` + `test_executor_allowed_tools` with `tester_allowed_tools` (Read, Glob, Grep, Write, Edit, Bash) |
| `agents/prompts.py` | Replaced `TEST_DESIGNER` + `TEST_EXECUTOR` with single `TESTER` prompt |
| `agents/coding.py` | Replaced `_invoke_test_designer` + `_invoke_test_executor` with `_invoke_tester`; updated Debugger context key and observability event strings |
| `config.py` | `test_designer_max_turns=15` + `test_executor_max_turns=100` → `tester_max_turns=115` |
| Unit / component / integration tests | Updated call counts, config assertions, persistence counts, settings construction |

## New fixture: `dbader/schedule`

Adds `tests/fixtures/schedule.json` with the first approved easy-tier entry:

- **`schedule-recursion-repr`** — `Job.__repr__` causes a `RecursionError` when the job is passed as its own argument (PR #277, issue #190, base SHA `3108fc3`)

Verified end-to-end: Plan → Coding → Review passed in 8m 49s at \$1.06. The ephemeral GitHub repo is preserved for review (created with `KEEP_FIXTURE_REPOS=1`).

The fixture research prompt and workflow doc are also updated to target **3 easy / 3 medium / 4 hard** (10 entries per repo) from the previous 3/1/1 (5 entries).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/agent_agent/` — no new errors (3 pre-existing)
- [ ] Unit tests: `pytest tests/unit/test_coding_composite.py`
- [ ] Component tests: `pytest tests/component/test_coding_composite.py`
- [ ] Integration e2e: `pytest tests/integration/test_phase5_e2e.py -m "integration and sdk" -k schedule-recursion-repr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)